### PR TITLE
Use base branch for PR to determine if it is a hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 run.sh
+release-notes

--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	repos    string
 	username string
 
+	hotfixOnly       bool
 	useCommits       bool
 	withReleaseNotes bool
 	withTesting      bool
@@ -40,6 +41,7 @@ func parseFlags() (config Config) {
 	flag.BoolVar(&config.useCommits, "commits", false, "use commits instead of issues")
 	flag.BoolVar(&config.withTesting, "with-testing", false, "include testing sections")
 	flag.BoolVar(&config.withReleaseNotes, "with-release-notes", true, "include release notes sections")
+	flag.BoolVar(&config.hotfixOnly, "hotfix-only", false, "show only hotfix issues")
 	flag.Parse()
 
 	if config.username == "" || config.password == "" || config.base == "" {


### PR DESCRIPTION
**What**
- Instead of relying on milestones, determine whether an issue is a hotfix based on branch it was merged into (i.e. if it is the current relase branch, it is a hotfix)
- Add an option to return hotfixes only

**Why**
Simplifies workflow by not requiring creation of milestones