### PR TITLE
Filter out "not release noted" issues

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,15 +14,16 @@ type Config struct {
 	repos    string
 	username string
 
-	hotfixOnly       bool
-	useCommits       bool
-	withReleaseNotes bool
-	withTesting      bool
+	hotfixOnly          bool
+	useCommits          bool
+	withNotReleaseNoted bool
+	withReleaseNotes    bool
+	withTesting         bool
 }
 
 func parseFlags() (config Config) {
 	flag.StringVar(&config.base, "since", "", "base branch for comparison (ex: release-20171212014000Z)")
-	flag.StringVar(&config.head, "until", "master", "head branch for comparison")
+	flag.StringVar(&config.head, "until", "", "head branch for comparison")
 	flag.StringVar(&config.password, "password", os.Getenv("GITHUB_TOKEN"), "(REQUIRED) github access token $GITHUB_TOKEN")
 	flag.StringVar(&config.username, "username", os.Getenv("GITHUB_USER"), "(REQUIRED) github username $GITHUB_USER")
 	flag.StringVar(&config.owner, "owner", "sagansystems", "github repo owner")
@@ -41,6 +42,7 @@ func parseFlags() (config Config) {
 	flag.BoolVar(&config.useCommits, "commits", false, "use commits instead of issues")
 	flag.BoolVar(&config.withTesting, "with-testing", false, "include testing sections")
 	flag.BoolVar(&config.withReleaseNotes, "with-release-notes", true, "include release notes sections")
+	flag.BoolVar(&config.withNotReleaseNoted, "with-not-release-noted", false, "include items labeled as 'not release noted'")
 	flag.BoolVar(&config.hotfixOnly, "hotfix-only", false, "show only hotfix issues")
 	flag.Parse()
 

--- a/issues.go
+++ b/issues.go
@@ -84,10 +84,12 @@ func (app IssuesApp) repoIssues(repo string) []Issue {
 		os.Exit(1)
 	}
 
-	url = fmt.Sprintf("search/issues?q=repo:sagansystems/%s+is:merged+base:%s", repo, app.config.head)
-	if err := app.github.Get(url, &res2); err != nil {
-		fmt.Printf("error fetching issues merged into release branch [%s]: %v", app.config.head, err)
-		os.Exit(1)
+	if app.config.head != "" {
+		url = fmt.Sprintf("search/issues?q=repo:sagansystems/%s+is:merged+base:%s", repo, app.config.head)
+		if err := app.github.Get(url, &res2); err != nil {
+			fmt.Printf("error fetching issues merged into release branch [%s]: %v", app.config.head, err)
+			os.Exit(1)
+		}
 	}
 
 	for _, item := range res.Items {

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 		app = NewIssuesApp(config, github)
 	}
 
-	filteredIssues := filterIssues(app.Issues(), config.hotfixOnly)
+	filteredIssues := filterIssues(app.Issues(), config.hotfixOnly, config.withNotReleaseNoted)
 	issuesByType := splitIssuesByType(filteredIssues)
 	if printIssues(bugFix, issuesByType[bugFix], config.withReleaseNotes, config.withTesting) {
 		fmt.Println("")
@@ -59,19 +59,24 @@ func printIssues(issueType string, issues []Issue, withReleaseNotes, withTesting
 		if issue.IsHotfix {
 			hotfix = "HOTFIX: "
 		}
+		issueNotReleaseNoted := ""
+		if contains(issue.Labels, notReleaseNoted) {
+			issueNotReleaseNoted = "NOT RELEASE NOTED: "
+		}
 
-		fmt.Printf("<b>%s%s</b><br/><a href=\"%s\">#%s</a>&nbsp;-&nbsp;%s<br/>%s%s<br/>\n",
-			hotfix, issue.Title, issue.URL, issue.Num, issue.Author, releaseNotes, testing)
+		fmt.Printf("<b>%s%s%s</b><br/><a href=\"%s\">#%s</a>&nbsp;-&nbsp;%s<br/>%s%s<br/>\n",
+			hotfix, issueNotReleaseNoted, issue.Title, issue.URL, issue.Num, issue.Author, releaseNotes, testing)
 	}
 
 	return true
 }
 
-func filterIssues(issues []Issue, hotfixOnly bool) []Issue {
+func filterIssues(issues []Issue, hotfixOnly, withNotReleaseNoted bool) []Issue {
 	var filteredIssues []Issue
 
 	for _, issue := range issues {
-		if !hotfixOnly || issue.IsHotfix {
+		releaseNoted := !contains(issue.Labels, notReleaseNoted)
+		if (!hotfixOnly || issue.IsHotfix) && (releaseNoted || withNotReleaseNoted) {
 			filteredIssues = append(filteredIssues, issue)
 		}
 	}


### PR DESCRIPTION
**What**
- By default, filter out issues marked as "not relesae noted" from the release notes
- Add a flag to include such items
- Tag "not release noted" issues as such

**Why**
The purpose of the "not release noted" label is to exclude such issues