### PR TITLE
Dockerize release-notes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:alpine AS builder
+
+ARG gopath="/go"
+
+ENV GOPATH=${gopath}
+
+COPY *.go $GOPATH/
+
+RUN go build -o release-notes
+
+FROM alpine:3.7
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /go/release-notes /release-notes
+
+ENTRYPOINT ["/release-notes"]


### PR DESCRIPTION
**What**
Initial commit to dockerize release-notes

once you build docker you can do:
`docker run -e GITHUB_TOKEN -e GITHUB_USER <image> -since release-20180116031542Z.2 -with-testing` etc.