### PR TITLE
Throttle search requests

### DIFF
--- a/github_client.go
+++ b/github_client.go
@@ -29,6 +29,10 @@ func (client Github) Get(path string, v interface{}) error {
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf(resp.Status)
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Why**
- Github imposes a limit of 30 requests per minute. With 4 search requests per repo and currently 10 repos, this means we need to throttle

**Who**
@gerad @mkj28 
cc @alexeits