### PR TITLE
Jenkinsize release-notes

### DIFF
--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -36,8 +36,8 @@ pipeline {
             }
 
             steps {
-                sh "/release-notes -since ${params.since} -until ${params.until} -withTesting=${params.withTesting} -withReleaseNotes=${params.withReleaseNotes} > output.html"
-                sh "echo release-notes -since ${params.since} -until ${params.until} -withTesting=${params.withTesting} -withReleaseNotes=${params.withReleaseNotes}"
+                sh "/release-notes -since ${params.since} -until ${params.until} -with-testing=${params.withTesting} -with-release-notes=${params.withReleaseNotes} > output.html"
+                sh "echo release-notes -since ${params.since} -until ${params.until} -with-testing=${params.withTesting} -withReleaseNotes=${params.withReleaseNotes}"
             }
         }
     }

--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -36,7 +36,7 @@ pipeline {
             }
 
             steps {
-                sh "release-notes -since ${params.since} -until ${params.until} -withTesting=${params.withTesting} -withReleaseNotes=${params.withReleaseNotes} > output.html"
+                sh "/release-notes -since ${params.since} -until ${params.until} -withTesting=${params.withTesting} -withReleaseNotes=${params.withReleaseNotes} > output.html"
                 sh "echo release-notes -since ${params.since} -until ${params.until} -withTesting=${params.withTesting} -withReleaseNotes=${params.withReleaseNotes}"
             }
         }

--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -11,12 +11,12 @@ pipeline {
 
     parameters {
         booleanParam(defaultValue: false, description: 'use commits instead of issues', name: 'commits')
-        booleanParam(defaultValue: false, description: 'show only hotfix issues', name: 'hotfix-only')
+        booleanParam(defaultValue: false, description: 'show only hotfix issues', name: 'hotfixOnly')
         string(defaultValue: '', description: 'base branch for comparison (ex: release-20171212014000Z)', name: 'since')
         string(defaultValue: '', description: 'head branch for comparison', name: 'until')
-        booleanParam(defaultValue: true, description: 'include items labeled as "not release noted"', name: 'internal')
-        booleanParam(defaultValue: true, description: 'include release notes sections', name: 'release-notes')
-        booleanParam(defaultValue: false, description: 'include testing sections', name: 'testing')
+        booleanParam(defaultValue: true, description: 'include items labeled as "not release noted"', name: 'withInternal')
+        booleanParam(defaultValue: true, description: 'include release notes sections', name: 'withReleaseNotes')
+        booleanParam(defaultValue: false, description: 'include testing sections', name: 'withTesting')
     }
 
     stages {
@@ -36,8 +36,8 @@ pipeline {
             }
 
             steps {
-                sh "release-notes -since ${params.since} -until ${params.until} -with-testing=${params.testing} -with-release-notes=${params.release-notes} > output.html"
-                sh "echo release-notes -since ${params.since} -until ${params.until} -with-testing=${params.testing} -with-release-notes=${params.release-notes}"
+                sh "release-notes -since ${params.since} -until ${params.until} -withTesting=${params.withTesting} -withReleaseNotes=${params.withReleaseNotes} > output.html"
+                sh "echo release-notes -since ${params.since} -until ${params.until} -withTesting=${params.withTesting} -withReleaseNotes=${params.withReleaseNotes}"
             }
         }
     }

--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -36,7 +36,7 @@ pipeline {
             }
 
             steps {
-                sh '/release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${with-release-notes} > output.html'
+                sh 'release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${with-release-notes} > output.html'
             }
         }
     }

--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -36,7 +36,7 @@ pipeline {
             }
 
             steps {
-                sh 'release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${params.with-release-notes} > output.html'
+                sh "release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${params.with-release-notes} > output.html"
             }
         }
     }

--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -1,0 +1,49 @@
+pipeline {
+    agent any
+    options {
+        timestamps()
+        timeout(time: 2, unit: 'HOURS')
+        buildDiscarder(logRotator(numToKeepStr:'10'))
+    }
+    environment {
+        JOB_USER = getJobUsername()
+    }
+
+    parameters {
+        booleanParam(defaultValue: false, description: 'use commits instead of issues', name: 'commits')
+        booleanParam(defaultValue: false, description: 'show only hotfix issues', name: 'hotfix-only')
+        string(defaultValue: '', description: 'base branch for comparison (ex: release-20171212014000Z)', name: 'since')
+        string(defaultValue: '', description: 'head branch for comparison', name: 'until')
+        booleanParam(defaultValue: true, description: 'include items labeled as "not release noted"', name: 'with-internal')
+        booleanParam(defaultValue: true, description: 'include release notes sections', name: 'with-release-notes')
+        booleanParam(defaultValue: false, description: 'include testing sections', name: 'with-testing')
+    }
+
+    stages {
+        stage('Generate release notes') {
+            agent { dockerfile true }
+
+            environment {
+                GITHUB_TOKEN = credentials('githubToken')
+                GITHUB_USER = 'saganbot'
+            }
+
+            post {
+                always {
+                    archiveArtifacts allowEmptyArchive: true, artifacts: '*.html'
+                    cleanWs()
+                }
+            }
+
+            steps {
+                sh '/release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${with-release-notes} > output.html'
+            }
+        }
+    }
+
+    post {
+        always {
+            cleanWs()
+        }
+    }
+}

--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -36,7 +36,7 @@ pipeline {
             }
 
             steps {
-                sh 'release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${with-release-notes} > output.html'
+                sh 'release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${params.with-release-notes} > output.html'
             }
         }
     }

--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -13,7 +13,7 @@ pipeline {
         booleanParam(defaultValue: false, description: 'use commits instead of issues', name: 'commits')
         booleanParam(defaultValue: false, description: 'show only hotfix issues', name: 'hotfixOnly')
         string(defaultValue: '', description: 'base branch for comparison (ex: release-20171212014000Z)', name: 'since')
-        string(defaultValue: '', description: 'head branch for comparison', name: 'until')
+        string(defaultValue: '', description: 'head branch for comparison, set to "" for empty', name: 'until')
         booleanParam(defaultValue: true, description: 'include items labeled as "not release noted"', name: 'withInternal')
         booleanParam(defaultValue: true, description: 'include release notes sections', name: 'withReleaseNotes')
         booleanParam(defaultValue: false, description: 'include testing sections', name: 'withTesting')

--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -10,17 +10,17 @@ pipeline {
     }
 
     parameters {
-        booleanParam(defaultValue: false, description: 'use commits instead of issues', name: 'commits')
-        booleanParam(defaultValue: false, description: 'show only hotfix issues', name: 'hotfixOnly')
         string(defaultValue: '', description: 'base branch for comparison (ex: release-20171212014000Z)', name: 'since')
         string(defaultValue: '', description: 'head branch for comparison, set to "" for empty', name: 'until')
         booleanParam(defaultValue: true, description: 'include items labeled as "not release noted"', name: 'withInternal')
         booleanParam(defaultValue: true, description: 'include release notes sections', name: 'withReleaseNotes')
         booleanParam(defaultValue: false, description: 'include testing sections', name: 'withTesting')
+        booleanParam(defaultValue: false, description: 'use commits instead of issues', name: 'commits')
+        booleanParam(defaultValue: false, description: 'show only hotfix issues', name: 'hotfixOnly')
     }
 
     stages {
-        stage('Generate release notes') {
+        stage('Generate release notes to "output.html" artifact') {
             agent { dockerfile true }
 
             environment {
@@ -31,13 +31,11 @@ pipeline {
             post {
                 always {
                     archiveArtifacts allowEmptyArchive: true, artifacts: '*.html'
-                    cleanWs()
                 }
             }
 
             steps {
-                sh "/release-notes -since ${params.since} -until ${params.until} -with-testing=${params.withTesting} -with-release-notes=${params.withReleaseNotes} > output.html"
-                sh "echo release-notes -since ${params.since} -until ${params.until} -with-testing=${params.withTesting} -withReleaseNotes=${params.withReleaseNotes}"
+                sh "/release-notes -since ${params.since} -until ${params.until} -with-testing=${params.withTesting} -with-release-notes=${params.withReleaseNotes} -commits=${params.commits} -hotfix-only=${params.hotfixOnly} -with-internal=${params.withInternal} > output.html"
             }
         }
     }

--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -37,6 +37,7 @@ pipeline {
 
             steps {
                 sh "release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${params.with-release-notes} > output.html"
+                sh "echo release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${params.with-release-notes}"
             }
         }
     }

--- a/.jenkins/release-notes.jenkins
+++ b/.jenkins/release-notes.jenkins
@@ -14,9 +14,9 @@ pipeline {
         booleanParam(defaultValue: false, description: 'show only hotfix issues', name: 'hotfix-only')
         string(defaultValue: '', description: 'base branch for comparison (ex: release-20171212014000Z)', name: 'since')
         string(defaultValue: '', description: 'head branch for comparison', name: 'until')
-        booleanParam(defaultValue: true, description: 'include items labeled as "not release noted"', name: 'with-internal')
-        booleanParam(defaultValue: true, description: 'include release notes sections', name: 'with-release-notes')
-        booleanParam(defaultValue: false, description: 'include testing sections', name: 'with-testing')
+        booleanParam(defaultValue: true, description: 'include items labeled as "not release noted"', name: 'internal')
+        booleanParam(defaultValue: true, description: 'include release notes sections', name: 'release-notes')
+        booleanParam(defaultValue: false, description: 'include testing sections', name: 'testing')
     }
 
     stages {
@@ -36,8 +36,8 @@ pipeline {
             }
 
             steps {
-                sh "release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${params.with-release-notes} > output.html"
-                sh "echo release-notes -since ${params.since} -until ${params.until} -with-testing=${params.with-testing} -with-release-notes=${params.with-release-notes}"
+                sh "release-notes -since ${params.since} -until ${params.until} -with-testing=${params.testing} -with-release-notes=${params.release-notes} > output.html"
+                sh "echo release-notes -since ${params.since} -until ${params.until} -with-testing=${params.testing} -with-release-notes=${params.release-notes}"
             }
         }
     }


### PR DESCRIPTION
Configured here: https://jenkins.gladly.qa/blue/organizations/jenkins/release-notes/activity

Generates to `output.html` artifact

seems to be working...

TODO (later... maybe) - generate list of branches for the dropdown....
